### PR TITLE
Add a small script to compare the odf data parsed by different methods

### DIFF
--- a/projects/odf_transform/test/compare_oce_vs_odf-read.py
+++ b/projects/odf_transform/test/compare_oce_vs_odf-read.py
@@ -1,0 +1,62 @@
+import glob
+import json
+import datetime
+
+import pandas as pd
+
+import cioos_data_transform.utils.odf as odf
+import cioos_data_transform.utils.oce as oce
+
+"""
+Small script use to compare the OCE method to read the data and the parsing tool available 
+within the cioos-data-transform package.
+"""
+
+decimal_rounding_value = 10
+
+odflist = glob.glob("./test_files/*.ODF")
+fulllist = glob.glob("./test_files/*")
+
+for f in odflist:
+    # Do we have both JSON and ODF available
+    if f not in fulllist or f + '.json' not in fulllist:
+        print('Missing JSON File:' + f)
+        break
+
+    # #### OCE JSON METHOD ####
+    # Load JSON
+    with open(f + '.json', "r") as fjson:
+        odf_json = json.load(fjson)
+
+    # Retrieve ODF Original Variable Attributes by digging in OCE
+    odf_json_variable_attributes = oce.get_odf_variable_attributes(odf_json['metadata'], prefix='original_')
+
+    # Retrieve ODF Original Data (Combine OCE data and Flags)
+    odf_json_data = oce.retrieve_odf_data_from_oce(odf_json['data'], odf_json['metadata'],
+                                                   odf_json_variable_attributes, 'original_')
+
+    # #### Read ODF directely with cioos_data_transform.utils.odf.read() ####
+    odf_read_header, odf_read_df = odf.read(f)
+
+    # #### Compare both methods variables ####
+    if len(odf_json_data) != len(odf_read_df.columns):
+        print('')
+
+    for var in odf_json_data:
+        compare_df = pd.DataFrame()
+        compare_df['json'] = odf_json_data[var]
+        compare_df['odf_read'] = odf_read_df[var]
+
+        # Convert to
+        # Review Float numerical data
+        if odf_read_df[var].dtype in ['datetime64[ns]']:
+            temp_time = (odf_read_df[var] - datetime.datetime(1970, 1, 1)).dt.total_seconds()
+            if (compare_df['json'].round(decimal_rounding_value) != temp_time.round(decimal_rounding_value)).any():
+                print(str(var) + ' dates are different')
+        # Review numerical data
+        elif compare_df['json'].dtype in ['float64', 'float', 'int', 'int64']:
+            if (compare_df['json'].round(decimal_rounding_value) !=
+                compare_df['odf_read'].round(decimal_rounding_value)).any():
+                print(var + ' values are different between the two methods')
+        else:
+            print("NOT SURE WHAT TO DO: " + str(var) + '[' + str(compare_df['json'].dtype) + ']')


### PR DESCRIPTION
Compare for now only the data with:
- OCE 
- cioos-data-transform.utils.odf.read()

I found that the OCE time data is different than the original data. It looks like the whole time variable gets converted to a single value within the range of the original time column.

No other differences are found for the other data types available within the test files.  This is related to issue #65