### PR TITLE
restore repo-wide readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,5 @@
-# cioos-siooc_data_transform
+# Data Transformation Tools
 
-## Getting started with ODF to NetCDF conversion development
+This project repository contains tools and packages used by the different CIOOS Regional Associations to import data from different formats and export to CIOOS compatible formats.
 
-1. Setup your Python3 virtual environment
-
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   ```
-
-1. Install ios_data_transform package
-
-   ```sh
-   cd cioos_data_transform/ios_data_transform
-   pip install -e .
-   ```
-
-1. Convert the sample ODF files to NetCDF, creating a folder 'temp' for output
-
-   ```sh
-   cd odf_transform/test
-   mkdir temp
-   python test_odf.py
-   ```
-
-1. Now temp will be full of NetCDF files
-
-   ```sh
-   ls temp
-   ```
+Documents describing purpose and installation details for each package are included in package specific folders.


### PR DESCRIPTION
Just putting back the repo's readme into this branch. Mostly so that we don't have to have 2 READMEs for the ODF project. The README for the ODF project is in the odf's project directory.